### PR TITLE
shrink max-width to 80% on mobile screens, shrink header

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -87,6 +87,15 @@ export default {
 </script>
 
 <style lang="scss">
+@media only screen and (max-width: 600px) {
+  .dropdown-content {
+  max-width: 80%;
+  }
+
+  .header {
+    font-size: 32px !important;
+  }
+}
 .search-bar {
   background-color: $color-teal;
   text-align: center;


### PR DESCRIPTION
shrinking the width of the dropdown to 80% of the screen on smaller (<600px wide) screens, also shrank the header font size to 32px when under the same <600px constraint.