### PR TITLE
Allow admins to disable or delete activities

### DIFF
--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -62,12 +62,24 @@
               <td>{{ activity.riskOver70 }}</td>
               <td>{{ activity.showLocation }}</td>
               <td><v-btn text icon @click="toggleActivityIsDisabled(activity.slug,activity.disabled)"><v-icon>{{ activityIsActive(activity.disabled)  }}</v-icon></v-btn></td>
-              <td><v-btn text icon @click="deleteActivity(activity.slug)"><v-icon>mdi-trash-can</v-icon></v-btn></td>
+              <td><v-btn text icon @click="showConfirmActivityDelete(activity.slug)"><v-icon>mdi-trash-can</v-icon></v-btn></td>
             </tr>
           </tbody>
         </table>
+        <v-dialog v-model="confirmActivityDelete" max-width="500">
+          <v-card>
+            <v-card-title>Are you sure you want to delete this activity?</v-card-title>
+            <v-card-text>{{this.activitySlugToDelete}}</v-card-text>
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn color="secondary darken-1" text @click="deleteActivity">Yes</v-btn>
+              <v-btn color="primary darken-1" text @click="confirmActivityDelete = false">No</v-btn>
+            </v-card-actions>
+          </v-card>
+          
+        </v-dialog>
         <div class="utilityShelf" v-show="showActivities">
-          <v-dialog v-model="showNewActivityPrompt" persistent max-width="500">
+          <v-dialog v-model="showNewActivityPrompt" max-width="500">
             <template v-slot:activator="{ on }">
               <v-btn class="buttonNew" color="dark" dark v-on="on">&#x2b; New</v-btn>
             </template>
@@ -299,6 +311,8 @@ export default {
       showNewActivityPrompt: false,
       newActivityName: "",
       activityAlreadyExistsError: false,
+      activitySlugToDelete: "",
+      confirmActivityDelete: false,
       currentUser: undefined,
       currentUserSettings: undefined
     };
@@ -440,12 +454,17 @@ export default {
           .child("disabled")
           .set(state);
     },
-    deleteActivity(activitySlug) {
+    deleteActivity() {
       db.ref("content")
         .child(this.currentCountry)
         .child("activities")
-        .child(activitySlug)
+        .child(this.activitySlugToDelete)
         .remove();
+        this.confirmActivityDelete = false;
+    },
+    showConfirmActivityDelete(activitySlug) {
+      this.activitySlugToDelete = activitySlug;
+      this.confirmActivityDelete = true;
     },
     deleteUser(userId) {
       db.ref("userSettings")

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -30,6 +30,8 @@
               <th>50-69</th>
               <th>70+</th>
               <th>location?</th>
+              <th></th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -59,6 +61,8 @@
               <td>{{ activity.risk50To69 }}</td>
               <td>{{ activity.riskOver70 }}</td>
               <td>{{ activity.showLocation }}</td>
+              <td><v-btn text icon @click="toggleActivityIsDisabled(activity.slug,activity.disabled)"><v-icon>{{ activityIsActive(activity.disabled)  }}</v-icon></v-btn></td>
+              <td><v-btn text icon @click="deleteActivity(activity.slug)"><v-icon>mdi-trash-can</v-icon></v-btn></td>
             </tr>
           </tbody>
         </table>
@@ -422,6 +426,26 @@ export default {
     },
     activityAlreadyExistsErrorOk() {
       this.newActivityName = "";
+    },
+    activityIsActive(disabled) {
+      if (disabled) return "mdi-eye-off";
+      else return "mdi-eye";
+    },
+    toggleActivityIsDisabled(activitySlug,state) {
+      state = !state;
+      db.ref("content")
+          .child(this.currentCountry)
+          .child("activities")
+          .child(activitySlug)
+          .child("disabled")
+          .set(state);
+    },
+    deleteActivity(activitySlug) {
+      db.ref("content")
+        .child(this.currentCountry)
+        .child("activities")
+        .child(activitySlug)
+        .remove();
     },
     deleteUser(userId) {
       db.ref("userSettings")

--- a/src/views/BrowseCategory.vue
+++ b/src/views/BrowseCategory.vue
@@ -31,7 +31,7 @@ export default {
     categoryActivities() {
       return Object.values(this.activities).filter(
         activity => activity.category === this.name
-      );
+      ).filter(activity => !activity.disabled);
     }
   }
 };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -52,7 +52,7 @@ export default {
     ...mapState(["userProfile", "currentCountry"]),
     ...mapGetters(["hasEnteredProfileData", "activities"]),
     activityList() {
-      return Object.values(this.activities || {}).map(
+      return Object.values(this.activities || {}).filter(activity => !activity.disabled).map(
         activity => activity.activityName
       );
     }


### PR DESCRIPTION
[#53] Admins can now disable or delete activities from the activities section of the admin page. Disabled activities will not show up in the select control of the search bar, nor the categories page of the browse category workflow.



┆Issue is synchronized with this [Trello card](https://trello.com/c/gfXSWLNF) by [Unito](https://www.unito.io/learn-more)
