### PR TITLE
Fixes link to protest-info PDF to be absoute [#102]

### DIFF
--- a/src/components/HomeBanner.vue
+++ b/src/components/HomeBanner.vue
@@ -1,6 +1,6 @@
 <template>
 <div>
-  <a href="./Protest_V2.pdf" target="_blank">
+  <a href="/Protest_V2.pdf" target="_blank">
   <v-alert 
   class="banner" 
   color="#fd6167" 


### PR DESCRIPTION
With the relative link, it was breaking when clicked after doing some
searching because it was going to /US/.



┆Issue is synchronized with this [Trello card](https://trello.com/c/2GeqKObg) by [Unito](https://www.unito.io/learn-more)
