### PR TITLE
[#160] Social Share Preview

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,8 +8,10 @@
     <meta property="og:description" content="Built to help you learn more about the risk of spreading COVID-19 posed by everyday activities.">
     <meta property="og:image" content="https://covidcanidoit.com/preview.png">
     <meta property="og:url" content="https://covidcanidoit.com/">
+    <meta property="og:type" content="website">
+    <meta property="fb:app_id" context="575714983333294">
 
-    <meta name="twitter:card" content="CCIDI" />
+    <meta name="twitter:card" content="summary" />
     <meta property="twitter:title" content="COVID - Can I do it?">
     <meta property="twitter:description" content="Built to help you learn more about the risk of spreading COVID-19 posed by everyday activities.">
     <meta property="twitter:image" content="https://covidcanidoit.com/preview.png">

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -249,9 +249,9 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://www.linkedin.com/in/tranjnnfr/"
-                    >Jennifer Tran</a
-                  >
+                  <a href="https://www.linkedin.com/in/tranjnnfr/">
+                    Jennifer Tran
+                  </a>
                 </li>
               </ul>
             </td>


### PR DESCRIPTION
* I'm unsure of why the fb:app id is needed and if I should use own associated with my own FB developer account or if we have one for CCIDI


I used https://cards-dev.twitter.com/validator to validate the twitter preview. I am not sure if http://socialsharepreview.com/ can reliably show what the preview will be on FB and LinkedIn
┆Issue is synchronized with this [Trello card](https://trello.com/c/YHvnS6gl) by [Unito](https://www.unito.io/learn-more)
