### PR TITLE
adding risk component dropdowns for mobile [#166]

### DIFF
--- a/src/components/RiskComponentDropdown.vue
+++ b/src/components/RiskComponentDropdown.vue
@@ -59,15 +59,17 @@ export default {
       return parseInt(this.activity[this.type]);
     },
     risk() {
-      return this.score === 1 ? "Low" : this.score === 2 ? "Medium" : "High";
+      const score = this.activity?.[this.type];
+      return this.riskLabels?.[score] || this.riskLabels["default"];
     },
     notes() {
-      return this.type !== "" ? this.activity[this.type + "Notes"] : "";
+      return this.type ? this.activity[`${this.type}Notes`] : "";
     },
     riskClass() {
-      return "risk" + this.risk;
+      return `risk${this.risk}`;
     }
-  }
+  },
+  data: () => ({ riskLabels: { "1": "Low", "2": "Medium", default: "High" } })
 };
 </script>
 

--- a/src/components/RiskComponentDropdown.vue
+++ b/src/components/RiskComponentDropdown.vue
@@ -1,20 +1,21 @@
 <template>
-  <v-row class="risk-component" justify="center" :class="riskClass">
-    <v-col cols="2" md="12">
-      <CrowdingIcon v-if="isCrowding" class="componentIcon" />
-      <DropletsIcon v-if="isDroplets" class="componentIcon" />
-      <TimeIcon v-if="isTime" class="componentIcon" />
-      <VentIcon v-if="isVent" class="componentIcon" />
-    </v-col>
-    <v-col cols="6" md="12">
-      <div class="componentTitle">{{ title }}</div>
-      <div class="componentRiskLabel">{{ risk }}</div>
-      <div class="notes">
-        <Markdown :source="notes" />
-        <!-- <v-btn>Learn more about {{ type }}</v-btn> -->
+  <v-expansion-panel class="riskComponentDropdown">
+    <v-expansion-panel-header class="d-flex flex-row">
+      <div :class="riskClass" class="componentIconContainer" flex-shrink-1>
+        <CrowdingIcon v-if="isCrowding" class="componentIcon" />
+        <DropletsIcon v-if="isDroplets" class="componentIcon" />
+        <TimeIcon v-if="isTime" class="componentIcon" />
+        <VentIcon v-if="isVent" class="componentIcon" />
       </div>
-    </v-col>
-  </v-row>
+      <div class="componentHeaderText" flex-grow-1>
+        <div class="componentTitle">{{ title }}</div>
+        <div class="componentRiskLabel">{{ risk }}</div>
+      </div>
+    </v-expansion-panel-header>
+    <v-expansion-panel-content>
+      <Markdown :source="notes" />
+    </v-expansion-panel-content>
+  </v-expansion-panel>
 </template>
 
 <script>
@@ -87,12 +88,28 @@ div .cls-2 {
 .riskHigh * {
   fill: $stopred;
 }
+.componentHeaderText {
+  font-size: 2em;
+  text-align: left;
+}
 .componentTitle {
-  font-weight: bold;
+  font-weight: 900;
+  margin-bottom: 0.25em;
+}
+.componentRiskLabel {
+  font-weight: 100;
+  color: $color-medgrey;
 }
 .notes {
   margin: 1em;
   text-align: left;
   font-size: 0.75em;
+}
+.riskComponentDropdown:nth-child(n + 2) {
+  border-top: 1px solid $color-lightgrey;
+}
+.componentIconContainer {
+  flex: 1 1 75 !important;
+  padding-right: 5em;
 }
 </style>

--- a/src/components/RiskComponents.vue
+++ b/src/components/RiskComponents.vue
@@ -14,7 +14,7 @@
         <RiskComponent :activity="activity" type="ventilation"></RiskComponent>
       </v-col>
     </v-row>
-    <v-row no-gutters v-if="!onMediumandUp">
+    <v-row no-gutters v-else>
       <v-col cols="12" sm-and-down>
         <v-expansion-panels flat>
           <RiskComponentDropdown
@@ -61,11 +61,7 @@ export default {
       );
     },
     maybeSeparator() {
-      if (this.$vuetify.breakpoint.mdAndUp) {
-        return "left-border";
-      } else {
-        return "top-border";
-      }
+      return this.$vuetify.breakpoint.mdAndUp ? "left-border" : "top-border";
     },
     onMediumandUp() {
       return this.$vuetify.breakpoint.mdAndUp;

--- a/src/components/RiskComponents.vue
+++ b/src/components/RiskComponents.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container v-if="hasRiskData">
-    <v-row>
+    <v-row v-if="onMediumandUp">
       <v-col cols="12" md="3" class="crowding">
         <RiskComponent :activity="activity" type="crowding"></RiskComponent>
       </v-col>
@@ -14,15 +14,39 @@
         <RiskComponent :activity="activity" type="ventilation"></RiskComponent>
       </v-col>
     </v-row>
+    <v-row no-gutters v-if="!onMediumandUp">
+      <v-col cols="12" sm-and-down>
+        <v-expansion-panels flat>
+          <RiskComponentDropdown
+            :activity="activity"
+            type="crowding"
+          ></RiskComponentDropdown>
+          <RiskComponentDropdown
+            :activity="activity"
+            type="droplets"
+          ></RiskComponentDropdown>
+          <RiskComponentDropdown
+            :activity="activity"
+            type="exposureTime"
+          ></RiskComponentDropdown>
+          <RiskComponentDropdown
+            :activity="activity"
+            type="ventilation"
+          ></RiskComponentDropdown>
+        </v-expansion-panels>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
 <script>
 import RiskComponent from "@/components/RiskComponent.vue";
+import RiskComponentDropdown from "@/components/RiskComponentDropdown.vue";
 
 export default {
   components: {
-    RiskComponent
+    RiskComponent,
+    RiskComponentDropdown
   },
   props: {
     activity: Object
@@ -42,6 +66,9 @@ export default {
       } else {
         return "top-border";
       }
+    },
+    onMediumandUp() {
+      return this.$vuetify.breakpoint.mdAndUp;
     }
   },
   methods: {},


### PR DESCRIPTION
this is my first attempt at switching to risk component dropdowns on mobile. I couldn't figure out a way to do it without some amount of duplication, so now, there is just both the columns and the dropdowns and we selectively hide one or the other based on whether we are on medium and up or not.

let me know if I should go back to the drawing board or whether this is something we could look into making more singular.

close #166



┆Issue is synchronized with this [Trello card](https://trello.com/c/SaKxBY87) by [Unito](https://www.unito.io/learn-more)
