### PR TITLE
remove beta restriction from phase 2 admin edit [#169]

### DIFF
--- a/src/components/RiskDescription.vue
+++ b/src/components/RiskDescription.vue
@@ -120,11 +120,6 @@ export default {
       }
       return referencesArray;
     },
-    showRiskComponents: function() {
-      return (
-        this.activity.activityName && this.currentUserSettings.hasBetaAccess
-      );
-    },
     regionsList: function() {
       return Object.values(this.regions);
     },

--- a/src/views/AdminActivityEdit.vue
+++ b/src/views/AdminActivityEdit.vue
@@ -5,7 +5,7 @@
     <h6>
       <small class="lastEdited">{{ lastEdited }}</small>
     </h6>
-    <v-form v-show="hasBetaAccess">
+    <v-form>
       <v-container fluid>
         <v-layout>
           <v-flex lg12 md12 sm12 xs12>


### PR DESCRIPTION
basically just allow all admins to use fancy schmancy new activity editor



┆Issue is synchronized with this [Trello card](https://trello.com/c/R5zgkd3t) by [Unito](https://www.unito.io/learn-more)
