### PR TITLE
Upping contrast values by making background white [#178]

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -206,7 +206,7 @@
           </tr>
           <tr>
             <td class="peopleGroup">
-              <ul style="list-style-type: none; padding: 0;">
+              <ul style="list-style-type: none; padding: 0px;">
                 <li>
                   <a href="https://www.linkedin.com/in/jarjiehfang/">
                     Jarjieh Fang, MPH
@@ -217,6 +217,12 @@
                     Gayatri Sanku, MPH
                   </a>
                 </li>
+                <li>
+                  <a href="https://www.linkedin.com/in/kstermer/">
+                    Katelyn Donnelly, MPH
+                  </a>
+                </li>
+
                 <li>
                   <a href="https://www.linkedin.com/in/mpaju-david-07606718a">
                     Mpaju David, MBChB V
@@ -229,10 +235,11 @@
                     Joseph Byamugisha, MBChB V
                   </a>
                 </li>
+                <li></li>
               </ul>
             </td>
             <td class="peopleGroup">
-              <ul style="list-style-type: none; padding: 0;">
+              <ul style="list-style-type: none; padding: 0px;">
                 <li>
                   <a href="https://www.linkedin.com/in/brockwilcox/">
                     Brock Wilcox, MS
@@ -263,7 +270,10 @@
               </ul>
             </td>
             <td class="peopleGroup">
-              <ul style="list-style-type: none; padding: 0;">
+              <ul style="list-style-type: none; padding: 0px;">
+                <li>
+                  Kasia Kujawski
+                </li>
                 <li>
                   <a href="https://www.linkedin.com/in/andrewloeb/">
                     Andrew Loeb
@@ -272,7 +282,20 @@
               </ul>
             </td>
             <td class="peopleGroup">
-              <ul style="list-style-type: none; padding: 0;">
+              <ul style="list-style-type: none; padding: 0px;">
+                <li>
+                  Tommy Scheurich
+                </li>
+                <li>
+                  <a href="https://www.linkedin.com/in/megangreendesign/">
+                    Megan Green
+                  </a>
+                </li>
+                <li>
+                  <a href="https://www.linkedin.com/in/clairemercer/">
+                    Claire Mercer
+                  </a>
+                </li>
                 <li>
                   <a href="https://www.linkedin.com/in/meera-nathan-371b15132/">
                     Meera Nathan
@@ -293,7 +316,7 @@
           </tr>
           <tr style="vertical-align: top;">
             <td class="peopleGroup">
-              <ul style="list-style-type: none; padding: 0;">
+              <ul style="list-style-type: none; padding: 0px;">
                 <li>
                   <a
                     href="https://www.linkedin.com/in/saskia-popescu-phd-mph-ma-cic-4ba9a334/"
@@ -309,7 +332,7 @@
               </ul>
             </td>
             <td class="peopleGroup">
-              <ul style="list-style-type: none; padding: 0;">
+              <ul style="list-style-type: none; padding: 0px;">
                 <li>
                   <a href="https://profiles.ucsf.edu/jayant.rajan">
                     Jayant Rajan, M.D., P.h.D
@@ -647,11 +670,13 @@ h5.mb-0 {
   color: $selectorgray;
 }
 .peopleGroup {
-  padding: 1px;
+  padding: 3px;
+  vertical-align: top;
 }
 
 .peopleGroupHeader {
-  font-weight: 300;
+  font-weight: bold;
+  padding-bottom: 0px;
 }
 .peopleBigHeader {
   font-size: 1.7em;

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -199,9 +199,9 @@
             <th class="peopleBigHeader">Who We Are</th>
           </tr>
           <tr>
-            <td class="peopleGroupHeader">Risk Assessment</td>
-            <td class="peopleGroupHeader">Development</td>
-            <td class="peopleGroupHeader">Public Relations</td>
+            <td class="peopleGroupHeader">Public Health</td>
+            <td class="peopleGroupHeader">Software Development</td>
+            <td class="peopleGroupHeader">Communications</td>
             <td class="peopleGroupHeader">Design</td>
           </tr>
           <tr>
@@ -218,24 +218,31 @@
                   </a>
                 </li>
                 <li>
+                  Andrew Zapfel, MPH
+                </li>
+                <li>
+                  Ariel Trocino, MPH
+                </li>
+                <li>
+                  Ashley Holub, MPH, PhD
+                </li>
+                <li>
+                  Christina Rawetzki, MPH
+                </li>
+                <li>
+                  Micquel Hart, MPH
+                </li>
+                <li>
                   <a href="https://www.linkedin.com/in/kstermer/">
                     Katelyn Donnelly, MPH
                   </a>
                 </li>
-
                 <li>
-                  <a href="https://www.linkedin.com/in/mpaju-david-07606718a">
-                    Mpaju David, MBChB V
-                  </a>
+                  Jessica Saddler, MPH(c)
                 </li>
                 <li>
-                  <a
-                    href="https://www.linkedin.com/in/joseph-byamugisha-44b313155"
-                  >
-                    Joseph Byamugisha, MBChB V
-                  </a>
+                  Swathi Nuli, MPH(c)
                 </li>
-                <li></li>
               </ul>
             </td>
             <td class="peopleGroup">
@@ -243,18 +250,6 @@
                 <li>
                   <a href="https://www.linkedin.com/in/brockwilcox/">
                     Brock Wilcox, MS
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="https://www.linkedin.com/in/david-kratochvil-1bb61a11b/"
-                  >
-                    David Kratochvil
-                  </a>
-                </li>
-                <li>
-                  <a href="https://www.linkedin.com/in/grant-hussey-a9854bb4/">
-                    Grant Hussey
                   </a>
                 </li>
                 <li>
@@ -267,25 +262,26 @@
                     Jennifer Tran
                   </a>
                 </li>
+                <li>
+                  Srilekha Nuli
+                </li>
+                <li>
+                  Alexa Stefankiewicz
+                </li>
               </ul>
             </td>
             <td class="peopleGroup">
               <ul style="list-style-type: none; padding: 0px;">
+                <li>
+                  Morgan Singer
+                </li>
                 <li>
                   Kasia Kujawski
                 </li>
-                <li>
-                  <a href="https://www.linkedin.com/in/andrewloeb/">
-                    Andrew Loeb
-                  </a>
-                </li>
               </ul>
             </td>
             <td class="peopleGroup">
               <ul style="list-style-type: none; padding: 0px;">
-                <li>
-                  Tommy Scheurich
-                </li>
                 <li>
                   <a href="https://www.linkedin.com/in/megangreendesign/">
                     Megan Green
@@ -297,9 +293,10 @@
                   </a>
                 </li>
                 <li>
-                  <a href="https://www.linkedin.com/in/meera-nathan-371b15132/">
-                    Meera Nathan
-                  </a>
+                  Elizabeth Hunt
+                </li>
+                <li>
+                  Tommy Scheurich, MS
                 </li>
               </ul>
             </td>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -2,8 +2,10 @@
   <div class="about">
     <!-- <HowItWorks /> -->
     <div class="infoHeader" style="margin:2em">
-      <h1>Questions You Might Have</h1>
-
+      <h1 style="text-align:center">About COVID Can I Do It?</h1>
+      <br />
+      <br />
+      <h3 style="color: #009898;">Frequently Asked Questions</h3>
       <div
         class="accordion md-accordion"
         id="accordionEx"
@@ -188,6 +190,9 @@
     </div>
     <div style="margin:2em">
       <div>
+        <br />
+        <hr style="border: 1px solid; color: #009898;" />
+        <br />
         <!--<h1>Who We Are</h1>-->
         <table class="weTable">
           <tr>
@@ -196,10 +201,12 @@
           <tr>
             <td class="peopleGroupHeader">Risk Assessment</td>
             <td class="peopleGroupHeader">Development</td>
+            <td class="peopleGroupHeader">Public Relations</td>
+            <td class="peopleGroupHeader">Design</td>
           </tr>
           <tr>
             <td class="peopleGroup">
-              <ul>
+              <ul style="list-style-type: none; padding: 0;">
                 <li>
                   <a href="https://www.linkedin.com/in/jarjiehfang/">
                     Jarjieh Fang, MPH
@@ -225,7 +232,7 @@
               </ul>
             </td>
             <td class="peopleGroup">
-              <ul>
+              <ul style="list-style-type: none; padding: 0;">
                 <li>
                   <a href="https://www.linkedin.com/in/brockwilcox/">
                     Brock Wilcox, MS
@@ -255,14 +262,8 @@
                 </li>
               </ul>
             </td>
-          </tr>
-          <tr>
-            <td class="peopleGroupHeader">Public Relations</td>
-            <td class="peopleGroupHeader">Design</td>
-          </tr>
-          <tr>
             <td class="peopleGroup">
-              <ul>
+              <ul style="list-style-type: none; padding: 0;">
                 <li>
                   <a href="https://www.linkedin.com/in/andrewloeb/">
                     Andrew Loeb
@@ -271,7 +272,7 @@
               </ul>
             </td>
             <td class="peopleGroup">
-              <ul>
+              <ul style="list-style-type: none; padding: 0;">
                 <li>
                   <a href="https://www.linkedin.com/in/meera-nathan-371b15132/">
                     Meera Nathan
@@ -280,6 +281,8 @@
               </ul>
             </td>
           </tr>
+          <br />
+          <br />
           <tr>
             <th class="peopleBigHeader">Who Our Advisors Are</th>
           </tr>
@@ -290,7 +293,7 @@
           </tr>
           <tr style="vertical-align: top;">
             <td class="peopleGroup">
-              <ul>
+              <ul style="list-style-type: none; padding: 0;">
                 <li>
                   <a
                     href="https://www.linkedin.com/in/saskia-popescu-phd-mph-ma-cic-4ba9a334/"
@@ -306,7 +309,7 @@
               </ul>
             </td>
             <td class="peopleGroup">
-              <ul>
+              <ul style="list-style-type: none; padding: 0;">
                 <li>
                   <a href="https://profiles.ucsf.edu/jayant.rajan">
                     Jayant Rajan, M.D., P.h.D
@@ -344,14 +347,13 @@ ent-residents/"
         or profits for this project.
       </p>
       <br />
-      <hr />
+      <hr style="border: 1px solid; color: #009898;" />
       <br />
       <div>
         <!-- Privacy Policy -->
         <!-- <b>
           <u>Your Privacy and Your Rights</u>
         </b> -->
-
         <h1>Information Collection Statement</h1>
         <p>
           We make this question and answer service available to you as a
@@ -617,31 +619,49 @@ export default {
 </script>
 
 <style lang="scss">
+a {
+  color: $selectorgray;
+}
 .about {
   margin: 0 2em;
-  border: 1px solid #ccc;
   background-color: #ffffff;
   .infoHeader {
     overflow-x: auto;
   }
 }
-.card-body {
-  background-color: $primary;
+div.card {
+  border: 0px;
+}
+div.card-header {
+  background-color: #ffffff;
+  color: $selectorgray;
+}
+div.card-header:hover {
+  background-color: darken(#ffffff, 5%);
+}
+div.card-body {
+  padding: 2em;
+  background-color: #ffffff;
+}
+h5.mb-0 {
+  color: $selectorgray;
 }
 .peopleGroup {
-  vertical-align: top;
+  padding: 1px;
 }
+
 .peopleGroupHeader {
-  font-weight: bold;
-  text-decoration: underline;
+  font-weight: 300;
 }
 .peopleBigHeader {
-  font-size: 2.5em;
+  font-size: 1.7em;
   padding-bottom: 0.5rem;
   padding-top: 1rem;
-  font-weight: 500;
+  font-weight: 300;
   line-height: 1.2;
+  color: $logodark;
 }
+
 .weTable {
   width: 100%;
   border-collapse: collapse;

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -620,7 +620,7 @@ export default {
 .about {
   margin: 0 2em;
   border: 1px solid #ccc;
-  background-color: $primary;
+  background-color: #ffffff;
   .infoHeader {
     overflow-x: auto;
   }


### PR DESCRIPTION
This isn't exactly the best solution, but I am following the color convention we have for links and the contrast is much higher, which is better than what we have now:

![Screen Shot 2020-07-20 at 4 22 37 PM](https://user-images.githubusercontent.com/12633533/87996019-f3633080-caa5-11ea-9a12-3852d03a8df1.png)
![Screen Shot 2020-07-20 at 4 25 32 PM](https://user-images.githubusercontent.com/12633533/87996021-f3fbc700-caa5-11ea-8b74-32945de2b1dc.png)



┆Issue is synchronized with this [Trello card](https://trello.com/c/5LGbQ0NB) by [Unito](https://www.unito.io/learn-more)
