### PR TITLE
[#168]: calculate riskScore based on region trends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+coverage/
 
 # Translations
 *.mo

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,10 @@ module.exports = {
   preset: "@vue/cli-plugin-unit-jest",
   verbose: true,
   moduleFileExtensions: ["js", "json", "vue"],
-  collectCoverageFrom: ["src/components/*.spec.{js,vue}", "!**/node_modules/**"]
+  collectCoverageFrom: [
+    "src/components/*.spec.{js,vue}",
+    "!**/node_modules/**"
+  ],
+  transformIgnorePatterns: ["/node_modules/(?!(vue-google-autocomplete)/)"],
+  setupFiles: ["./tests/unit/setup.js"]
 };

--- a/src/components/RiskDescription.vue
+++ b/src/components/RiskDescription.vue
@@ -37,9 +37,9 @@
           </span>
           <!--<div style="white-space: nowrap">has a risk level of</div>-->
         </div>
-        <div class="score">{{ risk.riskScore }}</div>
-        <div class="score-title">{{ risk.riskName }}</div>
-        <ScoreScale :score="score" />
+        <div class="score">{{ riskLevel.riskScore }}</div>
+        <div class="score-title">{{ riskLevel.riskName }}</div>
+        <ScoreScale :score="riskScore" />
         <v-select
           outlined
           return-object
@@ -74,7 +74,7 @@ export default {
     ActivitySearchbar
   },
   props: {
-    score: {
+    riskScore: {
       type: String,
       default: "5"
     },
@@ -101,8 +101,8 @@ export default {
       "regions",
       "activities"
     ]),
-    risk() {
-      return this.riskLevels["riskLevel" + this.score];
+    riskLevel() {
+      return this.riskLevels[`riskLevel${this.riskScore}`];
     },
     references: function() {
       var referencePropertyNames = Object.keys(this.activity).filter(
@@ -129,30 +129,17 @@ export default {
       return Object.values(this.regions);
     },
     activityRiskToken: function() {
-      let risk;
-      switch (this.score) {
-        case "1":
-          risk = "Low";
-          break;
-        case "2":
-          risk = "Moderate";
-          break;
-        case "3":
-          risk = "Elevated";
-          break;
-        case "4":
-          risk = "High";
-          break;
-        case "5":
-          risk = "Critical";
-          break;
-        default:
-          risk = "Uncertain";
-      }
-      return risk;
+      const riskTokenMap = {
+        "1": "Low",
+        "2": "Moderate",
+        "3": "Elevated",
+        "4": "High",
+        "5": "Critical"
+      };
+      return riskTokenMap?.[this.riskScore] || "Uncertain";
     },
     riskTokenClass: function() {
-      return "risk" + this.score;
+      return `risk${this.riskScore}`;
     },
     regionSelectClass: function() {
       if (this.$vuetify.breakpoint.mdAndUp) {

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,11 +1,7 @@
 <template>
   <div class="introduction" id="search-results">
     <div v-show="activity.activityName">
-      <RiskDescription
-        :score="activity.generalRiskScore"
-        :activity="activity"
-      />
-
+      <RiskDescription :riskScore="riskScore" :activity="activity" />
       <v-container>
         <v-row>
           <v-col
@@ -60,9 +56,21 @@ export default {
     return {};
   },
   computed: {
-    ...mapGetters(["riskFactors", "riskLevels"]),
+    ...mapGetters(["riskFactors", "riskLevels", "currentRegion", "regions"]),
     risk() {
-      return this.riskLevels["riskLevel" + this.activity.generalRiskScore];
+      return this.riskLevels[`riskLevel${this.riskScore}`];
+    },
+    riskScore() {
+      let score;
+      if (this.currentRegion !== "all") {
+        const scoreLookup = {
+          bad: this.activity?.TrendBadRiskScore,
+          medium: this.activity?.TrendMediumRiskScore,
+          good: this.activity?.TrendGoodRiskScore
+        };
+        score = scoreLookup?.[this.regions[this.currentRegion]?.trending];
+      }
+      return score || this.activity.generalRiskScore;
     }
   },
   methods: {}

--- a/tests/unit/SearchResults.spec.js
+++ b/tests/unit/SearchResults.spec.js
@@ -1,0 +1,113 @@
+import { createLocalVue, shallowMount } from "@vue/test-utils";
+import Vuex from "vuex";
+import SearchResults from "@/components/SearchResults.vue";
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe("SearchResults", () => {
+  describe("riskScore calculation", () => {
+    const regions = () => ({
+      all: {
+        trending: "bad",
+        slug: "all"
+      },
+      regionGood: {
+        trending: "good",
+        slug: "regionGood"
+      },
+      regionBad: {
+        trending: "bad",
+        slug: "regionBad"
+      },
+      regionMedium: {
+        trending: "medium",
+        slug: "regionMedium"
+      },
+      regionNoTrending: {
+        slug: "regionNoTrending"
+      },
+      regionInvalidTrending: {
+        trending: "none",
+        slug: "regionInvalidTrending"
+      }
+    });
+
+    const riskLevels = () => ({
+      riskLevel1: {
+        color: "",
+        longDescription: "",
+        riskName: "Low",
+        riskScore: "1"
+      },
+      riskLevel2: {
+        color: "",
+        longDescription: "",
+        riskName: "Moderate",
+        riskScore: "2"
+      },
+      riskLevel3: {
+        color: "",
+        longDescription: "",
+        riskName: "Elevated",
+        riskScore: "3"
+      },
+      riskLevel4: {
+        color: "",
+        longDescription: "",
+        riskName: "High",
+        riskScore: "4"
+      },
+      riskLevel5: {
+        color: "",
+        longDescription: "",
+        riskName: "Critical",
+        riskScore: "5"
+      }
+    });
+
+    test.each([
+      ["all", true, "1"],
+      ["regionGood", true, "2"],
+      ["regionMedium", true, "3"],
+      ["regionBad", true, "4"],
+      ["regionNoTrending", true, "1"],
+      ["regionInvalidTrending", true, "1"],
+      ["all", false, "1"],
+      ["regionGood", false, "1"],
+      ["regionMedium", false, "1"],
+      ["regionBad", false, "1"],
+      ["regionNoTrending", false, "1"],
+      ["regionInvalidTrending", false, "1"]
+    ])(
+      "when region is %p, activity has trending scores: %p, riskScore is %p",
+      (region, activityHasTrending, expected) => {
+        const activity = {
+          activityName: "Test activity",
+          generalRiskScore: "1",
+          slug: "test-activity",
+          ...(activityHasTrending && {
+            TrendBadRiskScore: "4",
+            TrendGoodRiskScore: "2",
+            TrendMediumRiskScore: "3"
+          })
+        };
+
+        const getters = {
+          currentRegion: () => region,
+          regions,
+          riskLevels,
+          riskFactors: () => {}
+        };
+        const store = new Vuex.Store({ getters });
+
+        const wrapper = shallowMount(SearchResults, {
+          localVue,
+          store,
+          propsData: { activity: activity }
+        });
+        expect(wrapper.vm.riskScore).toBe(expected);
+      }
+    );
+  });
+});

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,0 +1,4 @@
+import Vue from "vue";
+import Vuetify from "vuetify";
+
+Vue.use(Vuetify);


### PR DESCRIPTION
## Changes
* the risk score is now calculated based on region trends
  * if region is all, it falls back to the general risk score
* added jest setup file in order to make vuetify work with jest
* updated gitignore to include jest coverage output directory

## Testing instructions
### Search for 'playgrounds'
* for new york, the score should be 2
* for delaware, the score should be 3
* for california, the score should be 4
* for all, the score should be 4

### Search for 'attend a funeral'
* for new york, the score should be 1
* for delaware, the score should be 2
* for california, the score should be 3
* for all, the score should be 5

close #168



┆Issue is synchronized with this [Trello card](https://trello.com/c/Q2frMsK9) by [Unito](https://www.unito.io/learn-more)
