### PR TITLE
[#183]: refactor RiskComponents, fix dropdown styles

### DIFF
--- a/src/components/RiskComponent.vue
+++ b/src/components/RiskComponent.vue
@@ -1,98 +1,12 @@
-<template>
-  <v-row class="risk-component" justify="center" :class="riskClass">
+<template functional>
+  <v-row class="risk-component" justify="center">
     <v-col cols="2" md="12">
-      <CrowdingIcon v-if="isCrowding" class="componentIcon" />
-      <DropletsIcon v-if="isDroplets" class="componentIcon" />
-      <TimeIcon v-if="isTime" class="componentIcon" />
-      <VentIcon v-if="isVent" class="componentIcon" />
+      <slot name="icon" />
     </v-col>
     <v-col cols="6" md="12">
-      <div class="componentTitle">{{ title }}</div>
-      <div class="componentRiskLabel">{{ risk }}</div>
-      <div class="notes">
-        <Markdown :source="notes" />
-        <!-- <v-btn>Learn more about {{ type }}</v-btn> -->
-      </div>
+      <div class="componentTitle">{{ props.title }}</div>
+      <div class="componentRiskLabel">{{ props.riskLabel }}</div>
+      <slot name="notes" />
     </v-col>
   </v-row>
 </template>
-
-<script>
-import { mapGetters } from "vuex";
-import CrowdingIcon from "@/assets/Risk_Crowding-filled.svg";
-import DropletsIcon from "@/assets/Risk_Droplets-filled.svg";
-import TimeIcon from "@/assets/Risk_Time-filled.svg";
-import VentIcon from "@/assets/Risk_Ventilation-filled.svg";
-import Markdown from "vue-markdown";
-
-export default {
-  components: {
-    CrowdingIcon,
-    DropletsIcon,
-    TimeIcon,
-    VentIcon,
-    Markdown
-  },
-  props: {
-    activity: Object,
-    type: String
-  },
-  computed: {
-    ...mapGetters(["components"]),
-    isCrowding() {
-      return this.type === "crowding";
-    },
-    isDroplets() {
-      return this.type === "droplets";
-    },
-    isTime() {
-      return this.type === "exposureTime";
-    },
-    isVent() {
-      return this.type === "ventilation";
-    },
-    title() {
-      return this.components[this.type].title;
-    },
-    score() {
-      return parseInt(this.activity[this.type]);
-    },
-    risk() {
-      return this.score === 1 ? "Low" : this.score === 2 ? "Medium" : "High";
-    },
-    notes() {
-      return this.type !== "" ? this.activity[this.type + "Notes"] : "";
-    },
-    riskClass() {
-      return "risk" + this.risk;
-    }
-  }
-};
-</script>
-
-<style lang="scss">
-.componentIcon {
-  width: 75px;
-  height: 75px;
-}
-div .cls-2 {
-  fill: white;
-}
-.riskLow * {
-  fill: $gogreen;
-}
-.riskMedium * {
-  fill: $cautionyellow;
-}
-.riskHigh * {
-  fill: $stopred;
-}
-.componentTitle {
-  font-weight: bold;
-}
-.notes {
-  margin: 1em;
-  text-align: left;
-  font-size: 0.75em;
-}
-</style>

--- a/src/components/RiskComponentDropdown.vue
+++ b/src/components/RiskComponentDropdown.vue
@@ -1,123 +1,57 @@
 <template>
   <v-expansion-panel class="riskComponentDropdown">
     <v-expansion-panel-header class="d-flex flex-row">
-      <div
-        :class="riskClass"
-        class="componentIconContainer flex-shrink-1 flex-grow-0"
-      >
-        <CrowdingIcon v-if="isCrowding" class="componentIcon" />
-        <DropletsIcon v-if="isDroplets" class="componentIcon" />
-        <TimeIcon v-if="isTime" class="componentIcon" />
-        <VentIcon v-if="isVent" class="componentIcon" />
+      <div :class="riskClass" class="componentIconContainer flex-grow-0">
+        <slot name="icon" />
       </div>
-      <div class="componentHeaderText" flex-grow-1>
+      <div class="componentHeaderText">
         <div class="componentTitle">{{ title }}</div>
-        <div class="componentRiskLabel">{{ risk }}</div>
+        <div class="componentRiskLabel">{{ riskLabel }}</div>
       </div>
     </v-expansion-panel-header>
     <v-expansion-panel-content>
-      <Markdown :source="notes" class="component-notes" />
+      <div class="dropdown-notes">
+        <slot name="notes" />
+      </div>
     </v-expansion-panel-content>
   </v-expansion-panel>
 </template>
 
 <script>
-import { mapGetters } from "vuex";
-import CrowdingIcon from "@/assets/Risk_Crowding-filled.svg";
-import DropletsIcon from "@/assets/Risk_Droplets-filled.svg";
-import TimeIcon from "@/assets/Risk_Time-filled.svg";
-import VentIcon from "@/assets/Risk_Ventilation-filled.svg";
-import Markdown from "vue-markdown";
-
 export default {
-  components: {
-    CrowdingIcon,
-    DropletsIcon,
-    TimeIcon,
-    VentIcon,
-    Markdown
-  },
   props: {
-    activity: Object,
-    type: String
-  },
-  computed: {
-    ...mapGetters(["components"]),
-    isCrowding() {
-      return this.type === "crowding";
-    },
-    isDroplets() {
-      return this.type === "droplets";
-    },
-    isTime() {
-      return this.type === "exposureTime";
-    },
-    isVent() {
-      return this.type === "ventilation";
-    },
-    title() {
-      return this.components[this.type].title;
-    },
-    score() {
-      return parseInt(this.activity[this.type]);
-    },
-    risk() {
-      const score = this.activity?.[this.type];
-      return this.riskLabels?.[score] || this.riskLabels["default"];
-    },
-    notes() {
-      return this.type ? this.activity[`${this.type}Notes`] : "";
-    },
-    riskClass() {
-      return `risk${this.risk}`;
-    }
-  },
-  data: () => ({ riskLabels: { "1": "Low", "2": "Medium", default: "High" } })
+    type: String,
+    riskClass: String,
+    riskLabel: String,
+    notes: String,
+    title: String
+  }
 };
 </script>
 
-<style lang="scss">
-.componentIcon {
-  width: 75px;
-  height: 75px;
+<style scoped lang="scss">
+.v-expansion-panel-header {
+  padding: 16px 8px;
 }
-div .cls-2 {
-  fill: white;
+
+.v-expansion-panel-content {
+  padding-left: 0.5em;
 }
-.riskLow * {
-  fill: $gogreen;
-}
-.riskMedium * {
-  fill: $cautionyellow;
-}
-.riskHigh * {
-  fill: $stopred;
-}
+
 .componentHeaderText {
-  font-size: 2em;
   text-align: left;
+  margin-left: 1em;
 }
+
 .componentTitle {
+  font-size: 1.5em;
   font-weight: 900;
   margin-bottom: 0.25em;
 }
+
 .componentRiskLabel {
+  font-size: 1.25em;
   font-weight: 100;
   color: $color-medgrey;
-}
-.notes {
-  margin: 1em;
-  text-align: left;
-  font-size: 0.75em;
-}
-.component-notes {
-  margin: 1em;
-  text-align: left;
-}
-.riskComponentDropdown:nth-child(n + 2) {
-  border-top: 1px solid $color-lightgrey;
-}
-.componentIconContainer {
-  padding-right: 2em;
 }
 </style>

--- a/src/components/RiskComponents.vue
+++ b/src/components/RiskComponents.vue
@@ -76,7 +76,8 @@ export default {
     riskTypes: ["crowding", "droplets", "exposureTime", "ventilation"],
     riskLabels: {
       "1": "Low",
-      "2": "Medium"
+      "2": "Medium",
+      "3": "High"
     },
     icons: {
       crowding: CrowdingIcon,


### PR DESCRIPTION
## Changes
* hopefully decreases code repetition across RiskComponent/RiskComponentDropdown?
  * would love any feedback on this!
* fixes issue where dropdown overflows screen width
* fixes issue where dropdown header labels aren't aligned with each other
* change risk labels to say "Low Risk" instead of "Low" (this was suggested by someone on the public health team)

|Before (Mobile) | After (Mobile)|
|----|----|
|![Screen Shot 2020-07-22 at 19 50 40](https://user-images.githubusercontent.com/10696402/88357918-f6c31a00-cd3a-11ea-8fe8-6a8f9d8aaf31.png)![Screen Shot 2020-07-23 at 23 24 25](https://user-images.githubusercontent.com/10696402/88358102-ac8e6880-cd3b-11ea-9dc0-3123b14bdf73.png) |![Screen Shot 2020-07-23 at 23 22 47](https://user-images.githubusercontent.com/10696402/88358034-6fc27180-cd3b-11ea-91dd-586ae648dd85.png)![Screen Shot 2020-07-23 at 23 24 27](https://user-images.githubusercontent.com/10696402/88358113-b31ce000-cd3b-11ea-87a7-59279482839b.png)|

closes #183



┆Issue is synchronized with this [Trello card](https://trello.com/c/apC6M8pN) by [Unito](https://www.unito.io/learn-more)
