### PR TITLE
fix to infographic [#198]

### DIFF
--- a/src/views/Infographic.vue
+++ b/src/views/Infographic.vue
@@ -1,23 +1,24 @@
 <template>
-  <!-- <Infographic class="infographic" /> -->
-  <div class="infographicContainer">
-    <!-- <Infographic /> -->
-    <img
-      :src="
-        `${publicPath}images/riskcomponents/CCIDI_infographic_formatted.svg`
-      "
-      alt="Infographic"
-      class="infographic"
-    />
-  </div>
+  <v-container>
+    <v-layout row align-center justify-center>
+      <v-flex>
+        <div class="infographicContainer">
+          <img
+            :src="
+              `${publicPath}images/riskcomponents/CCIDI_infographic_formatted.svg`
+            "
+            alt="Infographic"
+            class="infographic"
+          />
+        </div>
+      </v-flex>
+    </v-layout>
+  </v-container>
 </template>
 
 <script>
-// import Infographic from "@/assets/CCIDI_infographic_formatted.svg";
 export default {
-  components: {
-    // Infographic
-  },
+  components: {},
   data() {
     return {
       publicPath: process.env.BASE_URL
@@ -28,6 +29,7 @@ export default {
 <style lang="scss" scoped>
 .infographic {
   margin: 0 auto;
+  max-width: 100%;
 }
 .infographicContainer {
   text-align: center;


### PR DESCRIPTION
Scaling issue is fixed in this PR, but the text is way too small. Because we're loading it in as an image, we cannot adjust the text, so perhaps we need to find some other way to load the infographic images into Vue. Perhaps if we break up the image into multiple smaller images, we wouldn't get the error about the call stack? Not sure if I should merge as is (users can do the two-finger pinch-pull zoom to read the text on mobile), or if we should wait to address the text size issue before proceeding. Let me know in the comments.

![image](https://user-images.githubusercontent.com/61799449/88488092-ee87fc00-cf3f-11ea-8fb0-898489874d51.png)

close #198



┆Issue is synchronized with this [Trello card](https://trello.com/c/vrwU53sz) by [Unito](https://www.unito.io/learn-more)
