### PR TITLE
189/score scale redesign

### DIFF
--- a/src/components/RiskComponents.vue
+++ b/src/components/RiskComponents.vue
@@ -10,11 +10,7 @@
       >
         <RiskComponent v-bind="risk" :class="risk.type">
           <template #icon>
-            <component
-              :is="icons[risk.type]"
-              class="component-icon"
-              :class="`${risk.riskClass}`"
-            />
+            <component :is="icons[risk.type]" class="component-icon" :class="`${risk.riskClass}`" />
           </template>
           <template #notes>
             <Markdown :source="risk.notes" class="notes desktop-notes" />
@@ -113,16 +109,12 @@ export default {
 <style scoped lang="scss">
 .component-icon {
   width: 75px;
-  &.riskLow > path {
-    fill: $gogreen;
+  $colors: (Low $gogreen, Medium $cautionyellow, High $stopred);
+  @each $risk, $color in $colors {
+    &.risk#{$risk} > path {
+      fill: $color;
+    }
   }
-  &.riskMedium > path {
-    fill: $cautionyellow;
-  }
-  &.riskHigh > path {
-    fill: $stopred;
-  }
-
   &.dropdown-icon {
     width: 48px;
   }

--- a/src/components/RiskDescription.vue
+++ b/src/components/RiskDescription.vue
@@ -98,7 +98,7 @@ export default {
       return riskTokenMap?.[this.riskScore] || "Uncertain";
     },
     riskTokenClass: function() {
-      return `risk${this.riskScore}`;
+      return `risk-${this.riskScore}`;
     },
     searchbarContainerClass: function() {
       if (this.$vuetify.breakpoint.mdAndUp) {
@@ -176,20 +176,6 @@ export default {
   .riskDeclare {
     font-size: 2em;
   }
-  .risk1 {
-    color: $gogreen;
-  }
-  .risk2 {
-    color: $pausegreen;
-  }
-  .risk3 {
-    color: $cautionyellow;
-  }
-  .risk4 {
-    color: $warningorange;
-  }
-  .risk5 {
-    color: $stopred;
-  }
+  @include risk-colors(".risk-", "color", $risk-colors);
 }
 </style>

--- a/src/components/ScoreScale.vue
+++ b/src/components/ScoreScale.vue
@@ -53,22 +53,7 @@ export default {
     width: 2.5em;
     height: 2.5em;
     color: white;
-
-    &.score-1 {
-      background-color: $gogreen;
-    }
-    &.score-2 {
-      background-color: $pausegreen;
-    }
-    &.score-3 {
-      background-color: $cautionyellow;
-    }
-    &.score-4 {
-      background-color: $warningorange;
-    }
-    &.score-5 {
-      background-color: $stopred;
-    }
+    @include risk-colors("&.score-", "background-color");
   }
 }
 

--- a/src/components/ScoreScale.vue
+++ b/src/components/ScoreScale.vue
@@ -1,38 +1,12 @@
-<template>
+<template functional>
   <div class="score-scale">
-    <div
-      class="score-scale-entry"
-      :class="[score == 1 ? 'selected selected-1' : '']"
-    >
-      1
-    </div>
-    <div class="connector"></div>
-    <div
-      class="score-scale-entry"
-      :class="[score == 2 ? 'selected selected-2' : '']"
-    >
-      2
-    </div>
-    <div class="connector"></div>
-    <div
-      class="score-scale-entry"
-      :class="[score == 3 ? 'selected selected-3' : '']"
-    >
-      3
-    </div>
-    <div class="connector"></div>
-    <div
-      class="score-scale-entry"
-      :class="[score == 4 ? 'selected selected-4' : '']"
-    >
-      4
-    </div>
-    <div class="connector"></div>
-    <div
-      class="score-scale-entry"
-      :class="[score == 5 ? 'selected selected-5' : '']"
-    >
-      5
+    <div v-for="n in 5" :key="n" class="score-scale__entry-wrapper">
+      <div
+        class="score-scale__entry"
+        :class="`score-${n} ${props.score == n ? 'selected' : ''}`"
+      >
+        <span>{{ n }}</span>
+      </div>
     </div>
   </div>
 </template>
@@ -46,53 +20,61 @@ export default {
 <style lang="scss">
 .score-scale {
   display: flex;
-  flex-direction: row;
   justify-content: center;
   align-items: center;
   margin-top: 1em;
-  vertical-align: middle;
+  text-align: center;
+  font-size: 1.5em;
 
-  .score-scale-entry {
-    // background-color: $color-medgrey;
-    color: black;
-    border: 2px solid $color-darkgrey;
-    border-radius: 16px;
-    width: 32px;
-    height: 32px;
-    line-height: 30px;
-    text-align: center;
+  .score-scale__entry-wrapper {
+    display: flex;
+    align-items: center;
+    &:not(:last-child):after {
+      content: "";
+      height: 2px;
+      background-color: $color-medgrey;
+      width: 0.75em;
+    }
   }
 
-  .connector {
-    height: 2px;
-    line-height: 2px;
-    background-color: $color-darkgrey;
-    width: 10px;
+  .score-scale__entry {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: $color-medgrey;
+    border: 2px solid $color-medgrey;
+    border-radius: 100%;
+    width: 1.5em;
+    height: 1.5em;
   }
 
   .selected {
-    border-radius: 30px;
-    width: 60px;
-    height: 60px;
-    line-height: 58px;
-    font-size: 2em;
+    border: none;
+    width: 2.5em;
+    height: 2.5em;
     color: white;
-  }
 
-  .selected-1 {
-    background-color: $gogreen;
+    &.score-1 {
+      background-color: $gogreen;
+    }
+    &.score-2 {
+      background-color: $pausegreen;
+    }
+    &.score-3 {
+      background-color: $cautionyellow;
+    }
+    &.score-4 {
+      background-color: $warningorange;
+    }
+    &.score-5 {
+      background-color: $stopred;
+    }
   }
-  .selected-2 {
-    background-color: $pausegreen;
-  }
-  .selected-3 {
-    background-color: $cautionyellow;
-  }
-  .selected-4 {
-    background-color: $warningorange;
-  }
-  .selected-5 {
-    background-color: $stopred;
+}
+
+@media #{map-get($display-breakpoints, 'md-and-up')} {
+  .score-scale {
+    font-size: 3em;
   }
 }
 </style>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -41,7 +41,7 @@
               <Markdown
                 class="risk-details"
                 :source="activity.additionalNotes"
-                v-if="activity.additionalNotes.length > 0"
+                v-if="activity.additionalNotes"
               />
               <Markdown class="risk-details" :source="risk.longDescription" />
             </div>
@@ -104,7 +104,7 @@ export default {
   }
 }
 
-.riskFactorDropdown:nth-child(n + 2) {
+.riskFactorDropdown:not(:first-child) {
   border-top: 1px solid $color-lightgrey;
 }
 .risk-factor-description {

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -7,14 +7,29 @@ $color-darkgrey: #333;
 $color-medgrey: #888;
 $color-lightgrey: #ccc;
 
-$primary: #B7DAD8;
-$secondary: #6DC8BF;
+$primary: #b7dad8;
+$secondary: #6dc8bf;
 $selectorgray: #003334;
 $logodark: #009898;
-$logolight: #71C8F0;
-$gogreen: #37B34A;
-$pausegreen: #98CA3C;
-$cautionyellow: #FAAF40;
-$warningorange: #C14432;
-$stopred: #A10C11;
+$logolight: #71c8f0;
+$gogreen: #37b34a;
+$pausegreen: #98ca3c;
+$cautionyellow: #faaf40;
+$warningorange: #c14432;
+$stopred: #a10c11;
 
+$risk-colors: (
+  1: $gogreen,
+  2: $pausegreen,
+  3: $cautionyellow,
+  4: $warningorange,
+  5: $stopred,
+);
+
+@mixin risk-colors($name, $prop, $args: $risk-colors) {
+  @each $ext, $color in $args {
+    #{$name}#{($ext)} {
+      #{$prop}: $color;
+    }
+  }
+}

--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -37,6 +37,13 @@ describe("Browsing Categories", () => {
   it("Click Activity in Category", () => {
     cy.contains("Errand");
     cy.contains(".activity-name", "Dog Walking").click();
+  });
+  it("Select region", () => {
+    cy.contains("Select a region/state");
+    cy.get(".v-select").type("a");
+  });
+
+  it("View risk page", () => {
     cy.contains("Dog");
     cy.contains("risk");
   });

--- a/tests/unit/CrowdingComponent.spec.js
+++ b/tests/unit/CrowdingComponent.spec.js
@@ -4,7 +4,6 @@ import CrowdingComponent from "@/components/crowdingComponent.vue";
 describe("CrowdingComponent", () => {
   describe("Methods", () => {
     const documentSpy = jest.spyOn(document, "getElementById");
-    const consoleSpy = jest.spyOn(console, "log");
 
     test("searchLocation should return the search location and set haveSearched to true", () => {
       const data = {
@@ -20,29 +19,8 @@ describe("CrowdingComponent", () => {
 
       documentSpy.mockReturnValueOnce({ value: "someValueForLocation" });
       wrapper.vm.searchLocation();
-      expect(data.selectedLocation).toMatchInlineSnapshot(
-        `"391 Amsterdam Ave"`
-      );
-      expect(consoleSpy).toBeCalled();
-      expect(consoleSpy).toMatchInlineSnapshot(`
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              "searched: ",
-              "someValueForLocation",
-              " at ",
-              "1:00 AM",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      `);
-      expect(wrapper.vm.$data.haveSearched).toBe(true);
+      expect(data.selectedLocation).toBe("391 Amsterdam Ave");
+      expect(wrapper.vm.$data.haveSearched).toBeTruthy();
     });
   });
 

--- a/tests/unit/ScoreScale.spec.js
+++ b/tests/unit/ScoreScale.spec.js
@@ -2,185 +2,26 @@ import { shallowMount } from "@vue/test-utils";
 import ScoreScale from "@/components/ScoreScale.vue";
 
 describe("ScoreScale", () => {
-  test("returns with class `connector`", () => {
+  test("all score entries have class 'score-scale-entry'", () => {
     const wrapper = shallowMount(ScoreScale);
-    expect(wrapper.findAll(".connector").length).toEqual(4);
+    expect(wrapper.findAll(".score-scale__entry").length).toEqual(5);
   });
 
-  test("returns with class `score-scale-entry", () => {
+  test("if no score is provided, no score will be selected", () => {
     const wrapper = shallowMount(ScoreScale);
-    expect(wrapper.findAll(".score-scale-entry").length).toEqual(5);
+    expect(wrapper.find(".selected").exists()).toBeFalsy();
   });
 
-  test("returns correctly without set score", () => {
-    const wrapper = shallowMount(ScoreScale);
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      <div class="score-scale">
-        <div class="score-scale-entry">
-          1
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          2
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          3
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          4
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          5
-        </div>
-      </div>
-    `);
-  });
+  test.each([[1], [2], [3], [4], [5]])(
+    "returns correctly with score set to 1",
+    score => {
+      const wrapper = shallowMount(ScoreScale, {
+        propsData: { score }
+      });
 
-  test("returns correctly with score set to 1", () => {
-    const wrapper = shallowMount(ScoreScale, {
-      propsData: { score: 1 }
-    });
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      <div class="score-scale">
-        <div class="score-scale-entry selected selected-1">
-          1
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          2
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          3
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          4
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          5
-        </div>
-      </div>
-    `);
-  });
-
-  test("returns correctly with score set to 2", () => {
-    const wrapper = shallowMount(ScoreScale, {
-      propsData: { score: 2 }
-    });
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      <div class="score-scale">
-        <div class="score-scale-entry">
-          1
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry selected selected-2">
-          2
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          3
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          4
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          5
-        </div>
-      </div>
-    `);
-  });
-
-  test("returns correctly with score set to 3", () => {
-    const wrapper = shallowMount(ScoreScale, {
-      propsData: { score: 3 }
-    });
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      <div class="score-scale">
-        <div class="score-scale-entry">
-          1
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          2
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry selected selected-3">
-          3
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          4
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          5
-        </div>
-      </div>
-    `);
-  });
-
-  test("returns correctly with score set to 4", () => {
-    const wrapper = shallowMount(ScoreScale, {
-      propsData: { score: 4 }
-    });
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      <div class="score-scale">
-        <div class="score-scale-entry">
-          1
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          2
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          3
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry selected selected-4">
-          4
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          5
-        </div>
-      </div>
-    `);
-  });
-
-  test("returns correctly with score set to 5", () => {
-    const wrapper = shallowMount(ScoreScale, {
-      propsData: { score: 5 }
-    });
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      <div class="score-scale">
-        <div class="score-scale-entry">
-          1
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          2
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          3
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry">
-          4
-        </div>
-        <div class="connector"></div>
-        <div class="score-scale-entry selected selected-5">
-          5
-        </div>
-      </div>
-    `);
-  });
+      const selectedScores = wrapper.findAll(".selected");
+      expect(selectedScores).toHaveLength(1);
+      expect(selectedScores.at(0).classes()).toContain(`score-${score}`);
+    }
+  );
 });


### PR DESCRIPTION
### Changes
* update score scale design to match designer mockup
* update risk colors to use sass mixins
* fix unit and e2e tests

|Mobile | Desktop|
|----|----|
|![Screen Shot 2020-07-27 at 23 11 49](https://user-images.githubusercontent.com/10696402/88614844-9dbaf500-d05e-11ea-8e0d-929276c02d5a.png) |![Screen Shot 2020-07-27 at 23 12 03](https://user-images.githubusercontent.com/10696402/88614846-a0b5e580-d05e-11ea-9cea-9d177746eb68.png)|

closes #189



┆Issue is synchronized with this [Trello card](https://trello.com/c/FAWNsPYB) by [Unito](https://www.unito.io/learn-more)
