### PR TITLE
Activity searching integrity fixes

### DIFF
--- a/src/components/SuggestedSearches.vue
+++ b/src/components/SuggestedSearches.vue
@@ -29,7 +29,6 @@ export default {
     this.searches = sampleSize(this.availableActivities, 6).map(
       activity => activity.name
     );
-    console.log(this.searches);
   },
   computed: {
     ...mapGetters(["activities"]),

--- a/src/components/SuggestedSearches.vue
+++ b/src/components/SuggestedSearches.vue
@@ -26,12 +26,18 @@ export default {
     };
   },
   created() {
-    this.searches = sampleSize(this.activities, 6).map(
+    this.searches = sampleSize(this.availableActivities, 6).map(
       activity => activity.name
     );
+    console.log(this.searches);
   },
   computed: {
-    ...mapGetters(["activities"])
+    ...mapGetters(["activities"]),
+    availableActivities() {
+      return Object.values(this.activities).filter(
+        activity => !activity.disabled
+      );
+    }
   },
   methods: {
     quickSearch(search) {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,7 +9,7 @@
     <SearchBar
       :initialSearchTerm="search"
       @searched="onSearch"
-      :activityList="activityList"
+      :activityList="activityNamesList"
       :perPage="5"
     />
     <SuggestedSearches @searched="onSearch" />
@@ -46,10 +46,13 @@ export default {
   },
   computed: {
     ...mapGetters(["activities", "currentCountry"]),
+    activityNamesList() {
+      return this.activityList.map(activity => activity.name);
+    },
     activityList() {
-      return Object.values(this.activities || {})
-        .filter(activity => !activity.disabled)
-        .map(activity => activity.name);
+      return Object.values(this.activities || {}).filter(
+        activity => !activity.disabled
+      );
     }
   },
   created() {
@@ -67,15 +70,19 @@ export default {
       }
 
       this.searched = true;
-      Object.values(this.activities).map(activity => {
+      for (let i = 0; i < this.activityList.length; i++) {
+        const activity = this.activityList[i];
+        if (!activity["name"]) continue;
         if (activity["name"].toLowerCase() == searchValue.toLowerCase()) {
           this.result = activity;
           if (this.$route.params.slug != activity.slug) {
-            this.selectedActivitySlug = activity.slug;
-            this.goToResults();
+            this.$router.push({
+              name: "ActivitySearch",
+              params: { slug: activity.slug }
+            });
           }
         }
-      });
+      }
     },
     goToResults() {
       this.$router.push({

--- a/src/views/SearchResults.vue
+++ b/src/views/SearchResults.vue
@@ -14,8 +14,11 @@
     </v-dialog>
 
     <div v-if="!shouldForceRegionSelect">
-      <ThanksForSuggesting v-if="noResults" :suggested="suggested" />
-      <SearchResults :activity="result" :searched="searched" />
+      <SearchResults
+        v-if="activityHasBeenSet"
+        :activity="result"
+        :searched="searched"
+      />
       <SuggestedSearches @searched="onSearch" />
     </div>
   </div>
@@ -25,7 +28,6 @@
 import { mapGetters } from "vuex";
 
 import SearchResults from "@/components/SearchResults.vue";
-import ThanksForSuggesting from "@/components/ThanksForSuggesting.vue";
 import SuggestedSearches from "@/components/SuggestedSearches.vue";
 import RegionSelector from "@/components/RegionSelector.vue";
 
@@ -33,7 +35,6 @@ export default {
   props: ["search", "slug"],
   components: {
     SearchResults,
-    ThanksForSuggesting,
     SuggestedSearches,
     RegionSelector
   },
@@ -42,15 +43,19 @@ export default {
       searched: false,
       result: {},
       noResults: false,
-      suggested: ""
+      suggested: "",
+      activityHasBeenSet: false
     };
   },
   computed: {
     ...mapGetters(["activities", "currentCountry", "currentRegion", "regions"]),
     activityList() {
-      return Object.values(this.activities || {})
-        .filter(activity => !activity.disabled)
-        .map(activity => activity.name);
+      return Object.values(this.activities || {}).filter(
+        activity => !activity.disabled
+      );
+    },
+    activityNamesList() {
+      return this.activityList.map(activity => activity.name);
     },
     shouldForceRegionSelect() {
       return (
@@ -62,6 +67,10 @@ export default {
     if (this.slug) {
       this.onSearch(this.activities[this.slug].name);
     }
+  },
+  mounted() {
+    this.result = this.activities[this.slug];
+    this.activityHasBeenSet = true;
   },
   methods: {
     onSearch(searchValue) {
@@ -76,7 +85,9 @@ export default {
       }
 
       this.searched = true;
-      Object.values(this.activities).map(activity => {
+      for (let i = 0; i < this.activityList.length; i++) {
+        const activity = this.activityList[i];
+        if (!activity["name"]) continue;
         if (activity["name"].toLowerCase() == searchValue.toLowerCase()) {
           this.result = activity;
           if (this.$route.params.slug != activity.slug) {
@@ -86,7 +97,7 @@ export default {
             });
           }
         }
-      });
+      }
     },
 
     onSuggest(suggestValue) {


### PR DESCRIPTION
Fixing some buggy code that could cause problems like we saw at the end of the first week of launch. 

I did see that the SearchResults component (not view) kept loading before the activity was set in the prop. I tried all sorts of things to stop it, like `v-if="activity"`, but it didn't help because for some reason, being a data object, it was automatically assigned some kind of Observer type? I ultimately used a boolean to determine whether the activity was set:


```vue
<template>
  <div v-if="!shouldForceRegionSelect">
      <SearchResults
        v-if="activityHasBeenSet"
        :activity="result"
        :searched="searched"
      />
      <SuggestedSearches @searched="onSearch" />
    </div>
</template>

export default {
  data: function() {
    return {
      searched: false,
      result: {},
      noResults: false,
      suggested: "",
      activityHasBeenSet: false
    };
  },
  mounted() {
    this.result = this.activities[this.slug];
    this.activityHasBeenSet = true;
  },
}
```

Not super proud, but this was the only way I could get it to work. Let me know if there's something else I should try.

close #236 close #235

┆Issue is synchronized with this [Trello card](https://trello.com/c/fJjNnrcN) by [Unito](https://www.unito.io/learn-more)
