### PR TITLE
add jest coverage, unit test pre-push hook

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,6 @@
 {
   "hooks": {
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "pre-push": "yarn test:unit"
   }
 }

--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ info@covidcanidoit.com and we can get you set up with the slack and meetings.
 
 ## Technology overview
 
-* [VueJS](https://vuejs.org/)
-* [Vuetify](https://vuetifyjs.com/)
-* [Firebase Hosting](https://firebase.google.com/docs/hosting)
-* [Firebase Database](https://firebase.google.com/docs/database)
+- [VueJS](https://vuejs.org/)
+- [Vuetify](https://vuetifyjs.com/)
+- [Firebase Hosting](https://firebase.google.com/docs/hosting)
+- [Firebase Database](https://firebase.google.com/docs/database)
 
 ## Dev workflow
 
-* Initial project setup
-* Create/update branch and develop locally
-* Open a PR, automatically runs tests
-* Optional: Deploy to staging
-* Merges to master automatically deploy to production
+- Initial project setup
+- Create/update branch and develop locally
+- Open a PR, automatically runs tests
+- Optional: Deploy to staging
+- Merges to master automatically deploy to production
 
 ### Initial Project Setup
 
@@ -43,13 +43,14 @@ Git, github, and technical fork/branch management is a little out of scope here,
 
 This project uses `nodejs`, `yarn`, and `vue-cli`, so to get started you should have nodejs and yarn installed. We recommend `asdf` as your version manager:
 
-* Install [asdf](https://asdf-vm.com/#/core-manage-asdf-vm) (possibly using [brew](https://brew.sh/))
-* Install [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs)
-* Install nodejs itself
-* Install yarn
-* Install project dependencies
+- Install [asdf](https://asdf-vm.com/#/core-manage-asdf-vm) (possibly using [brew](https://brew.sh/))
+- Install [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs)
+- Install nodejs itself
+- Install yarn
+- Install project dependencies
 
 #### Full MacOS Example
+
 This is a from-scratch installation. Hopefully you can copy/paste bits of ths
 at a time into a terminal. If you have brew, asdf, nodejs, or yarn, then you
 can skip those parts.
@@ -103,7 +104,7 @@ yarn deploy-staging
 yarn deploy-db-rules
 
 # Run your tests
-yarn test:unit # ... we don't have any of these yet
+yarn test:unit # html test coverage report is viewable at ./coverage/lcov-report/index.html
 yarn test:e2e  # uses cypress / headless-chrome
 
 # Lint (and fix) cruft
@@ -116,11 +117,11 @@ This project is hosted on Firebase, using both Firebase Hosting (for
 compiled/static content) and the Firebase Realtime Database (for the activities
 database and other dynamic content).
 
-* `yarn build` compiles vue components and assets into .js files
-* These assets and compiled js files are uploaded to Firebase Hosting, and are directly served to browsers
-* The browsers are then running the VueJS app
-* The app uses Firebase Database API to get (realitime) data from the Firebase Database. This is how the app gets the actual COVID activities and risk scores
-* There is an admin section in the app that also uses the Database API to update activities
-* Based on project needs, sometimes we do a bulk-data-import using tools in the `utils/` directory
-* We have a separate firebase project named `ccidi-staging` that does all of the same things, which is nice for testing infrastructure and major database changes
-* The Google Places API doesn't provide busyness data directly, so there is also an API service that uses the [populartimes](https://github.com/m-wrzr/populartimes) python library to scrape this data. Right now this is hosted on @awwaiid's server, but we'll move it into a Google Cloud function at some point
+- `yarn build` compiles vue components and assets into .js files
+- These assets and compiled js files are uploaded to Firebase Hosting, and are directly served to browsers
+- The browsers are then running the VueJS app
+- The app uses Firebase Database API to get (realitime) data from the Firebase Database. This is how the app gets the actual COVID activities and risk scores
+- There is an admin section in the app that also uses the Database API to update activities
+- Based on project needs, sometimes we do a bulk-data-import using tools in the `utils/` directory
+- We have a separate firebase project named `ccidi-staging` that does all of the same things, which is nice for testing infrastructure and major database changes
+- The Google Places API doesn't provide busyness data directly, so there is also an API service that uses the [populartimes](https://github.com/m-wrzr/populartimes) python library to scrape this data. Right now this is hosted on @awwaiid's server, but we'll move it into a Google Cloud function at some point

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,9 @@ module.exports = {
   preset: "@vue/cli-plugin-unit-jest",
   verbose: true,
   moduleFileExtensions: ["js", "json", "vue"],
+  collectCoverage: true,
   collectCoverageFrom: [
-    "src/components/*.spec.{js,vue}",
+    "src/{components,views}/*.{js,vue}",
     "!**/node_modules/**"
   ],
   transformIgnorePatterns: ["/node_modules/(?!(vue-google-autocomplete)/)"],


### PR DESCRIPTION
### Changes
* add jest coverage functionality
  * this prints out a jest test coverage report in the terminal when running unit tests
![Screen Shot 2020-08-13 at 8 05 37 PM](https://user-images.githubusercontent.com/10696402/90198788-bdf9ec00-dda0-11ea-8746-dae1ff5522e0.png)
  * right now it's just pulling coverage from `/views` and `/components` let me know if we should add more paths!
* add note in readme about html jest coverage report
* add unit test pre-commit hook
  * requires that unit tests pass before allowing commits to be pushed to origin
  * can be overridden with `--no-verify` flag
  * we could add e2e tests too if we wanted?
  * this is just a thought I had, let me know if you think this wouldn't be right for our workflow!

┆Issue is synchronized with this [Trello card](https://trello.com/c/BpzoNXF3) by [Unito](https://www.unito.io/learn-more)
