### PR TITLE
#202 added FAQ copy

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -23,8 +23,7 @@
               aria-controls="collapseOne1"
             >
               <h5 class="mb-0">
-                How does adding the location and time of my activities change
-                the risk?
+                What is COVID Can I Do It?
                 <i class="fas fa-angle-down rotate-icon"></i>
               </h5>
             </a>
@@ -36,6 +35,247 @@
             class="collapse show"
             role="tabpanel"
             aria-labelledby="headingOne1"
+            data-parent="#accordionEx"
+          >
+            <div class="card-body">
+              <p>
+                COVID Can I Do It? or CCIDI is a digital, mobile-friendly tool
+                that aims to help anyone, anywhere assess their risks for
+                COVID-19 transmission and be empowered to make informed choices
+                to prevent further spread. The tool is undergoing extensive
+                updates to emphasize a mobile-first experience, return risk
+                ratings based on key COVID-19 control measures, and focus on
+                helping users understand why activities are risky and how to
+                reduce risk.
+              </p>
+
+              <p>
+                <strong>CCIDI aims to:</strong>
+              </p>
+              <ol>
+                <li>Make risk relatable</li>
+                <li>Equip people with the skills to mitigate risk</li>
+                <li>Point people to more information</li>
+                <li>Help people understand the scientific context</li>
+              </ol>
+            </div>
+          </div>
+        </div>
+        <div class="card">
+          <!-- Card header -->
+          <div class="card-header" role="tab" id="headingTwo2">
+            <a
+              data-toggle="collapse"
+              data-parent="#accordionEx"
+              href="#collapseTwo2"
+              aria-expanded="false"
+              aria-controls="collapseTwo2"
+            >
+              <h5 class="mb-0">
+                How does it work?
+                <i class="fas fa-angle-down rotate-icon"></i>
+              </h5>
+            </a>
+          </div>
+
+          <!-- Card body -->
+          <div
+            id="collapseTwo2"
+            class="collapse"
+            role="tabpanel"
+            aria-labelledby="headingTwo2"
+            data-parent="#accordionEx"
+          >
+            <div class="card-body">
+              <p>
+                CCIDI relies on epidemiological data from CovidExitStrategy.org,
+                scientific literature and crowding information from Google Maps.
+                The tool doesn’t store any personal user data or information.
+                CCIDI leaders develop educational tools, screen news sources,
+                provide UX testing and evaluate newly requested activities based
+                on evidence.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <!-- Card header -->
+          <div class="card-header" role="tab" id="headingThree3">
+            <a
+              data-toggle="collapse"
+              data-parent="#accordionEx"
+              href="#collapseThree3"
+              aria-expanded="false"
+              aria-controls="collapseThree3"
+            >
+              <h5 class="mb-0">
+                Who is COVID Can I Do It?
+                <i class="fas fa-angle-down rotate-icon"></i>
+              </h5>
+            </a>
+          </div>
+
+          <!-- Card body -->
+          <div
+            id="collapseThree3"
+            class="collapse"
+            role="tabpanel"
+            aria-labelledby="headingThree3"
+            data-parent="#accordionEx"
+          >
+            <div class="card-body">
+              <p>
+                CCIDI comprises a team of public health practitioners, web
+                developers, public relations and graphic design professionals.
+                The tool is reviewed by a panel of expert reviewers and
+                clinicians. Any funding for the tool is supplied through grants.
+                Our co-leads are Jarjieh Fang, MPH, Gayatri Sanku, MPH, and
+                Andrew Zapfel, MPH.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <!-- Card header -->
+          <div class="card-header" role="tab" id="headingFour4">
+            <a
+              data-toggle="collapse"
+              data-parent="#accordionEx"
+              href="#collapseFour4"
+              aria-expanded="false"
+              aria-controls="collapseFour4"
+            >
+              <h5 class="mb-0">
+                Where is COVID Can I Do It?
+                <i class="fas fa-angle-down rotate-icon"></i>
+              </h5>
+            </a>
+          </div>
+
+          <!-- Card body -->
+          <div
+            id="collapseFour4"
+            class="collapse"
+            role="tabpanel"
+            aria-labelledby="headingFour4"
+            data-parent="#accordionEx"
+          >
+            <div class="card-body">
+              <p>
+                The COVID Can I Do It? Team has deployed the tool in the U.S.,
+                Uganda, and the Philippines, with plans to expand to other
+                countries and regions. If you are interested in bringing the
+                tool to your city or country, contact us at
+                info@covidcanidoit.com.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <!-- Card header -->
+          <div class="card-header" role="tab" id="headingFive5">
+            <a
+              data-toggle="collapse"
+              data-parent="#accordionEx"
+              href="#collapseFive5"
+              aria-expanded="false"
+              aria-controls="collapseFive5"
+            >
+              <h5 class="mb-0">
+                Why COVID Can I Do It?
+                <i class="fas fa-angle-down rotate-icon"></i>
+              </h5>
+            </a>
+          </div>
+
+          <!-- Card body -->
+          <div
+            id="collapseFive5"
+            class="collapse"
+            role="tabpanel"
+            aria-labelledby="headingFive5"
+            data-parent="#accordionEx"
+          >
+            <div class="card-body">
+              <p>
+                The novel coronavirus pandemic has unveiled many gaps in our
+                healthcare system and infrastructure, and the public can help
+                end the pandemic. With the U.S. and other countries reopening
+                amid limited practical guidance and geographical differences,
+                there needs to be a tool to support people’s decision-making on
+                daily activities that equips people with the skills needed to
+                reduce and/or avoid risk.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <!-- Card header -->
+          <div class="card-header" role="tab" id="headingSix6">
+            <a
+              data-toggle="collapse"
+              data-parent="#accordionEx"
+              href="#collapseSix6"
+              aria-expanded="false"
+              aria-controls="collapseSix6"
+            >
+              <h5 class="mb-0">
+                How can I partner with COVID Can I Do It?
+                <i class="fas fa-angle-down rotate-icon"></i>
+              </h5>
+            </a>
+          </div>
+
+          <!-- Card body -->
+          <div
+            id="collapseSix6"
+            class="collapse"
+            role="tabpanel"
+            aria-labelledby="headingSix6"
+            data-parent="#accordionEx"
+          >
+            <div class="card-body">
+              <p>
+                As we continue to empower citizens to mitigate risk, we welcome
+                public health teams from other countries and regions to deploy
+                the tool for their local community. We are also looking for help
+                with expert guidance and review, expansion of user awareness and
+                access, and support for grants management. If you’re interested
+                in joining as an advisor, partner or country team, please reach
+                out to info@covidcanidoit.com.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <!-- Card header -->
+          <div class="card-header" role="tab" id="headingSeven7">
+            <a
+              data-toggle="collapse"
+              data-parent="#accordionEx"
+              href="#collapseSeven7"
+              aria-expanded="false"
+              aria-controls="collapseSeven7"
+            >
+              <h5 class="mb-0">
+                How does adding the location and time of my activities change
+                the risk?
+                <i class="fas fa-angle-down rotate-icon"></i>
+              </h5>
+            </a>
+          </div>
+
+          <!-- Card body -->
+          <div
+            id="collapseSeven7"
+            class="collapse"
+            role="tabpanel"
+            aria-labelledby="headingSeven7"
             data-parent="#accordionEx"
           >
             <div class="card-body">
@@ -55,14 +295,14 @@
         </div>
         <div class="card">
           <!-- Card header -->
-          <div class="card-header" role="tab" id="headingTwo2">
+          <div class="card-header" role="tab" id="headingEight8">
             <a
               class="collapsed"
               data-toggle="collapse"
               data-parent="#accordionEx"
-              href="#collapseTwo2"
+              href="#collapseEight8"
               aria-expanded="false"
-              aria-controls="collapseTwo2"
+              aria-controls="collapseEight8"
             >
               <h5 class="mb-0">
                 If I am diagnosed with one of the additional disease and
@@ -74,10 +314,10 @@
 
           <!-- Card body -->
           <div
-            id="collapseTwo2"
+            id="collapseEight8"
             class="collapse"
             role="tabpanel"
-            aria-labelledby="headingTwo2"
+            aria-labelledby="headingEight8"
             data-parent="#accordionEx"
           >
             <div class="card-body">
@@ -99,14 +339,14 @@
         </div>
         <div class="card">
           <!-- Card header -->
-          <div class="card-header" role="tab" id="headingThree3">
+          <div class="card-header" role="tab" id="headingNine9">
             <a
               class="collapsed"
               data-toggle="collapse"
               data-parent="#accordionEx"
-              href="#collapseThree3"
+              href="#collapseNine9"
               aria-expanded="false"
-              aria-controls="collapseThree3"
+              aria-controls="collapseNine9"
             >
               <h5 class="mb-0">
                 What does CovidCanIDoIt do with the information I provide?
@@ -117,10 +357,10 @@
 
           <!-- Card body -->
           <div
-            id="collapseThree3"
+            id="collapseNine9"
             class="collapse"
             role="tabpanel"
-            aria-labelledby="headingThree3"
+            aria-labelledby="headingNine9"
             data-parent="#accordionEx"
           >
             <div class="card-body">
@@ -140,15 +380,18 @@
               </p>
             </div>
           </div>
+        </div>
 
-          <div class="card-header" role="tab" id="headingFour4">
+        <div class="card">
+          <!-- Card header -->
+          <div class="card-header" role="tab" id="headingTen10">
             <a
               class="collapsed"
               data-toggle="collapse"
               data-parent="#accordionEx"
-              href="#collapseFour4"
+              href="#collapseTen10"
               aria-expanded="false"
-              aria-controls="collapseFour4"
+              aria-controls="collapseTen10"
             >
               <h5 class="mb-0">
                 Can I rely on CovidCanIDoIt for medical advice?
@@ -159,10 +402,10 @@
 
           <!-- Card body -->
           <div
-            id="collapseFour4"
+            id="collapseTen10"
             class="collapse"
             role="tabpanel"
-            aria-labelledby="headingFour4"
+            aria-labelledby="headingTen10"
             data-parent="#accordionEx"
           >
             <div class="card-body">


### PR DESCRIPTION
Added basic copy to About Page FAQ section.  E2E test still failing due to 'Dog' being not found on Risk page.

Does not appear to conflict with PR from #227 

I've heard mention of a redesign so I didn't refactor anything, but currently it seems DRY and hard to read with the bootstrap cards.  I suggest for the refactor/redesign to perhaps creating a component for each FAQ card and passing in props and/or slots?  