### PR TITLE
Adjust font size and spacing for popular times caption [#264]

### DIFF
--- a/src/components/PopularTimesChart.vue
+++ b/src/components/PopularTimesChart.vue
@@ -312,11 +312,17 @@ a {
   @media #{map-get($display-breakpoints, 'sm-and-down')} {
     font-size: 0.6em;
   }
+
+  @media #{map-get($display-breakpoints, 'md-only')} {
+    font-size: 0.75em;
+  }
+
+  padding-left: 0.5em;
 }
 
 #canvasContainer {
   width: 35vw;
-  height: 20vw;
+  height: 20.5vw;
   @media #{map-get($display-breakpoints, 'sm-and-down')} {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
Anyone mind just double checking this in another os/browser? Besides the font size adjustment for medium devices I added a global left padding because it seemed necessary, unless this is inconsistent with other components on the site?



┆Issue is synchronized with this [Trello card](https://trello.com/c/P6nAMKea) by [Unito](https://www.unito.io/learn-more)
