### PR TITLE
feat: Make think about risk labels clickable

### DIFF
--- a/src/components/HowToThinkAboutRisk.vue
+++ b/src/components/HowToThinkAboutRisk.vue
@@ -4,28 +4,42 @@
     <h5>Click to learn more</h5>
     <v-container>
       <v-row>
-        <v-col cols="6" md="3">
+        <v-col cols="6" md="3" class="howToThinkAboutRisk__icon-container">
           <CrowdingIcon
             class="componentIcon"
             @click="onComponentIconClick('crowding')"
           ></CrowdingIcon>
-          <div class="componentLabel">Crowding</div>
+          <div @click="onComponentIconClick('crowding')" class="componentLabel">
+            Crowding
+          </div>
         </v-col>
-        <v-col cols="6" md="3">
+        <v-col cols="6" md="3" class="howToThinkAboutRisk__icon-container">
           <DropletsIcon
             class="componentIcon"
             @click="onComponentIconClick('droplets')"
           ></DropletsIcon>
-          <div class="componentLabel">Droplets</div>
+          <div class="componentLabel" @click="onComponentIconClick('droplets')">
+            Droplets
+          </div>
         </v-col>
-        <v-col cols="6" md="3">
+        <v-col cols="6" md="3" class="howToThinkAboutRisk__icon-container">
           <TimeIcon
             class="componentIcon"
             @click="onComponentIconClick('exposureTime')"
           ></TimeIcon>
-          <div class="componentLabel">Time</div>
+          <div
+            class="componentLabel"
+            @click="onComponentIconClick('exposureTime')"
+          >
+            Time
+          </div>
         </v-col>
-        <v-col cols="6" md="3">
+        <v-col
+          cols="6"
+          md="3"
+          class="howToThinkAboutRisk__icon-container"
+          @click="onComponentIconClick('ventilation')"
+        >
           <VentIcon
             class="componentIcon"
             @click="onComponentIconClick('ventilation')"
@@ -131,6 +145,7 @@ export default {
   fill: rgba(0, 0, 0, 0);
   border: 2px solid black;
   border-radius: 50%;
+  cursor: pointer;
 }
 .componentIcon:hover {
   cursor: pointer;
@@ -142,8 +157,17 @@ export default {
     fill: black;
   }
 }
+.howToThinkAboutRisk__icon-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
 .componentLabel {
   margin-top: 1em;
+  display: inline;
+  padding: 10px;
+  cursor: pointer;
 }
 div .cls-2 {
   fill: black;

--- a/src/components/HowToThinkAboutRisk.vue
+++ b/src/components/HowToThinkAboutRisk.vue
@@ -4,35 +4,32 @@
     <h5>Click to learn more</h5>
     <v-container>
       <v-row>
-        <v-col cols="6" md="3" class="howToThinkAboutRisk__icon-container">
-          <CrowdingIcon
-            class="componentIcon"
-            @click="onComponentIconClick('crowding')"
-          ></CrowdingIcon>
-          <div @click="onComponentIconClick('crowding')" class="componentLabel">
-            Crowding
-          </div>
+        <v-col
+          cols="6"
+          md="3"
+          class="howToThinkAboutRisk__icon-container"
+          @click="onComponentIconClick('crowding')"
+        >
+          <CrowdingIcon class="componentIcon"></CrowdingIcon>
+          <div class="componentLabel">Crowding</div>
         </v-col>
-        <v-col cols="6" md="3" class="howToThinkAboutRisk__icon-container">
-          <DropletsIcon
-            class="componentIcon"
-            @click="onComponentIconClick('droplets')"
-          ></DropletsIcon>
-          <div class="componentLabel" @click="onComponentIconClick('droplets')">
-            Droplets
-          </div>
+        <v-col
+          cols="6"
+          md="3"
+          class="howToThinkAboutRisk__icon-container"
+          @click="onComponentIconClick('droplets')"
+        >
+          <DropletsIcon class="componentIcon"></DropletsIcon>
+          <div class="componentLabel">Droplets</div>
         </v-col>
-        <v-col cols="6" md="3" class="howToThinkAboutRisk__icon-container">
-          <TimeIcon
-            class="componentIcon"
-            @click="onComponentIconClick('exposureTime')"
-          ></TimeIcon>
-          <div
-            class="componentLabel"
-            @click="onComponentIconClick('exposureTime')"
-          >
-            Time
-          </div>
+        <v-col
+          cols="6"
+          md="3"
+          class="howToThinkAboutRisk__icon-container"
+          @click="onComponentIconClick('exposureTime')"
+        >
+          <TimeIcon class="componentIcon"></TimeIcon>
+          <div class="componentLabel">Time</div>
         </v-col>
         <v-col
           cols="6"
@@ -40,10 +37,7 @@
           class="howToThinkAboutRisk__icon-container"
           @click="onComponentIconClick('ventilation')"
         >
-          <VentIcon
-            class="componentIcon"
-            @click="onComponentIconClick('ventilation')"
-          ></VentIcon>
+          <VentIcon class="componentIcon"></VentIcon>
           <div class="componentLabel">Ventilation</div>
         </v-col>
       </v-row>
@@ -145,7 +139,6 @@ export default {
   fill: rgba(0, 0, 0, 0);
   border: 2px solid black;
   border-radius: 50%;
-  cursor: pointer;
 }
 .componentIcon:hover {
   cursor: pointer;
@@ -162,12 +155,12 @@ export default {
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  cursor: pointer;
 }
 .componentLabel {
   margin-top: 1em;
   display: inline;
   padding: 10px;
-  cursor: pointer;
 }
 div .cls-2 {
   fill: black;


### PR DESCRIPTION
This PR solves #185 

How to think about risks are not clickable and show the relative modal. Moreover, the pointer was set to pointer since the icon and the label are clickable.



┆Issue is synchronized with this [Trello card](https://trello.com/c/ThIdRaaE) by [Unito](https://www.unito.io/learn-more)
