### PR TITLE
Fix: Desktop Activity Page - Fix "Click on a bar" Break Point

### DIFF
--- a/src/views/Browse.vue
+++ b/src/views/Browse.vue
@@ -3,7 +3,7 @@
     <v-col cols="12" md="8" offset-md="2">
       <h1 class="browse-header">Browse activities by category</h1>
     </v-col>
-    <v-col cols="12" md="6" offset-md="3">
+    <v-col cols="12" md="6" offset-md="3" class="category">
       <v-expansion-panels flat class="categories">
         <v-expansion-panel
           v-for="category in categories"


### PR DESCRIPTION
### Issue
https://github.com/covidcanidoit/covidcanidoit/issues/275


### Before
![image](https://user-images.githubusercontent.com/20719656/95936676-5859c880-0e00-11eb-9f9c-1a180f088d86.png)

### Result
![image](https://user-images.githubusercontent.com/20719656/95936543-09ac2e80-0e00-11eb-8513-2bcdb1cef998.png)
![image](https://user-images.githubusercontent.com/20719656/95936560-129d0000-0e00-11eb-947e-0f6b20b4ce3b.png)



┆Issue is synchronized with this [Trello card](https://trello.com/c/33GUdeBE) by [Unito](https://www.unito.io/learn-more)
