### PR TITLE
Fixed Highlight Active Page in Hamburger Menu

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,42 +54,44 @@
             </v-list>
           </v-menu>
         </v-list-item>
-        <v-list-item link>
-          <router-link
-            class="router"
-            :to="{
-              name: 'Home',
-              params: { country: currentCountry, region: currentRegion }
-            }"
-          >
-            Home
-          </router-link>
-        </v-list-item>
-        <v-list-item link>
-          <router-link
-            class="router"
-            :to="{
-              name: 'Browse',
-              params: { country: currentCountry, region: currentRegion }
-            }"
-          >
-            Activities
-          </router-link>
-        </v-list-item>
-        <v-list-item link>
-          <a href="//blog.covidcanidoit.com/">Blog</a>
-        </v-list-item>
-        <v-list-item link>
-          <router-link
-            class="router"
-            :to="{
-              name: 'About',
-              params: { country: currentCountry, region: currentRegion }
-            }"
-          >
-            About
-          </router-link>
-        </v-list-item>
+        <div class="nav-buttons">
+            <v-list-item link>
+            <router-link
+                class="router"
+                :to="{
+                name: 'Home',
+                params: { country: currentCountry, region: currentRegion }
+                }"
+            >
+                Home
+            </router-link>
+            </v-list-item>
+            <v-list-item link>
+            <router-link
+                class="router"
+                :to="{
+                name: 'Browse',
+                params: { country: currentCountry, region: currentRegion }
+                }"
+            >
+                Activities
+            </router-link>
+            </v-list-item>
+            <v-list-item link>
+            <a href="//blog.covidcanidoit.com/">Blog</a>
+            </v-list-item>
+            <v-list-item link>
+            <router-link
+                class="router"
+                :to="{
+                name: 'About',
+                params: { country: currentCountry, region: currentRegion }
+                }"
+            >
+                About
+            </router-link>
+            </v-list-item>
+        </div>
       </v-list>
     </v-navigation-drawer>
 
@@ -307,7 +309,7 @@ body {
     color: $secondary;
   }
 
-  header {
+  .nav-buttons {
     a,
     a:visited,
     a:hover {
@@ -317,9 +319,9 @@ body {
       text-decoration: none;
     }
 
-    .nav-buttons a.router-link-exact-active,
-    .nav-buttons a.router-link-exact-active:visited,
-    .nav-buttons a.router-link-exact-active:hover {
+    a.router-link-exact-active,
+    a.router-link-exact-active:visited,
+    a.router-link-exact-active:hover {
       white-space: nowrap;
       border-radius: 30px;
       padding: 2px 7px;


### PR DESCRIPTION
This fixes issue #279 

The list items inside navigation drawer that are for page navigation were wrapped in '.nav-buttons'-class;
Styling was adjusted to adress the '.nav-buttons'-class in header and nav drawer the same way.

![image](https://user-images.githubusercontent.com/10882212/96436465-431cd980-1206-11eb-8d32-7dbcc7fdc599.png)

**Additional suggestion:**
As of right now the navigation drawer buttons are "hard to hit" because the buttons are kind of small and there is no visible indication where they actually are.
This could be fixed by changing the width of the `<a>` to 100%.
Highlighting could be changed to "full row" as well, which would make it a lot easier to hit the links.

![image](https://user-images.githubusercontent.com/10882212/96437358-7d867680-1206-11eb-9602-2cbe77437e3e.png)



┆Issue is synchronized with this [Trello card](https://trello.com/c/EiprEyDE) by [Unito](https://www.unito.io/learn-more)
