### PR TITLE
fix halloween image blocking clicks of suggested searches

### DIFF
--- a/src/components/SuggestedSearches.vue
+++ b/src/components/SuggestedSearches.vue
@@ -113,6 +113,7 @@ export default {
   @media #{map-get($display-breakpoints, 'sm-and-down')} {
     opacity: 0.15;
     position: absolute;
+    pointer-events: none;
   }
 }
 </style>


### PR DESCRIPTION
fixes the bug of the halloween image blocking the suggested searches from being clicked when on mobile.



┆Issue is synchronized with this [Trello card](https://trello.com/c/Bh1s1vLY) by [Unito](https://www.unito.io/learn-more)
