### PR TITLE
Fixed 'close'-button of modal dialog

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -891,6 +891,7 @@ export default {
   },
   data() {
     return {
+      dialogInfoCollectStatement: false,
       publicHealth: [
         {
           name: "Jarjieh Fang, MPH",


### PR DESCRIPTION
This fixes the 'close'-button of the 'Information Collect Statement' modal dialog.

Issue was raised in #291



┆Issue is synchronized with this [Trello card](https://trello.com/c/bVnHF2GT) by [Unito](https://www.unito.io/learn-more)
