### PR TITLE
How to Think About Risk Fixes

### DIFF
--- a/src/components/HowToThinkAboutRisk.vue
+++ b/src/components/HowToThinkAboutRisk.vue
@@ -3,7 +3,7 @@
     <h1>How to think about risk</h1>
     <h5>Click to learn more</h5>
     <v-container>
-      <v-layout>
+      <v-layout wrap>
         <v-flex
           cols="6"
           md="3"
@@ -167,6 +167,8 @@ export default {
   align-items: center;
   flex-direction: column;
   cursor: pointer;
+  margin: 0 0.25rem 1rem 0.25rem;
+  flex: 1;
 }
 .componentLabel {
   margin-top: 1em;

--- a/src/components/HowToThinkAboutRisk.vue
+++ b/src/components/HowToThinkAboutRisk.vue
@@ -124,6 +124,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.howToThinkAboutRisk {
+  h1,
+  .h1 {
+    @media screen and (max-width: 500px) {
+      font-size: 1.5rem;
+    }
+  }
+}
 .learnMoreContainer {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Updates
* decreases font size of the how to think about risk header on mobile
* makes the risk icons wrap to prevent overflow
closes #297 closes #276 

### Testing instructions
1. Open homepage
1. Confirm that the header/icons are unchanged on desktop
1. Shrink screen
1. Confirm that the icons wrap and do not overflow the container
1. Confirm that at 320px the header is only two lines

![Screen Shot 2021-05-14 at 19 46 21](https://user-images.githubusercontent.com/10696402/118200766-e8f29880-b423-11eb-8557-15615a0fcbb5.png)



┆Issue is synchronized with this [Trello card](https://trello.com/c/u4VW2JyZ) by [Unito](https://www.unito.io)
